### PR TITLE
pass the command argument into Devel::Mutator::Command::Test constructor

### DIFF
--- a/script/mutator
+++ b/script/mutator
@@ -26,7 +26,8 @@ elsif ($opts->{test}) {
     exit Devel::Mutator::Command::Test->new(
         verbose => ($opts->{'-v'} || $opts->{'--verbose'}),
         remove  => $opts->{'--remove'},
-        timeout => $opts->{'--timeout'}
+        timeout => $opts->{'--timeout'},
+	command => $opts->{'--command'}
     )->run;
 }
 


### PR DESCRIPTION
The command argument is missing when mutator calls Devel::Mutator::Command::Test constructor, which means the script never runs the command passed as command-line argument, otherwise the default command value (prove -l t) is always run.
